### PR TITLE
Refactor DbContext usage for Blazor concurrency safety

### DIFF
--- a/Services/DependencyInjection.cs
+++ b/Services/DependencyInjection.cs
@@ -25,8 +25,20 @@ public static class DependencyInjection
         services.AddOptions<AdminSeedOptions>().BindConfiguration(AdminSeedOptions.SectionName);
 
         // Database.
+        //
+        // Register a DbContext *factory* so repositories can each own a short-lived context.
+        // Under Blazor Static SSR + ReactiveBlazor, multiple components on one page (plus
+        // out-of-band signal re-renders) execute concurrently; a single shared scoped context
+        // throws "A second operation was started on this context instance...". The factory
+        // hands out isolated contexts per operation and avoids that race.
+        //
+        // ASP.NET Identity still needs a scoped AppDbContext for its stores. AddDbContextFactory
+        // registers the context as singleton-options; we add a scoped AppDbContext from the same
+        // factory so Identity gets its own per-request instance without a second options config.
         var connectionString = config.GetConnectionString("DefaultConnection");
-        services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
+        services.AddDbContextFactory<AppDbContext>(options => options.UseNpgsql(connectionString));
+        services.AddScoped<AppDbContext>(sp =>
+            sp.GetRequiredService<IDbContextFactory<AppDbContext>>().CreateDbContext());
 
         // TMDB typed client.
         services.AddHttpClient<ITmdbClient, TmdbClient>((sp, http) =>
@@ -36,8 +48,10 @@ public static class DependencyInjection
         });
 
         // Application services.
-        services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
-        services.AddScoped<IMediaRequestRepository, MediaRequestRepository>();
+        // Repositories are transient: each owns a context from the factory, so concurrent
+        // components never share one and dispose it when they go out of scope.
+        services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
+        services.AddTransient<IMediaRequestRepository, MediaRequestRepository>();
         services.AddScoped<IEmailSender, SmtpEmailSender>();
         services.AddSingleton<IProfilePictureStore, FileSystemProfilePictureStore>();
         services.AddSingleton<IEmbedUrlBuilder, EmbedUrlBuilder>();

--- a/Services/Repositories/MediaRequestRepository.cs
+++ b/Services/Repositories/MediaRequestRepository.cs
@@ -6,7 +6,7 @@ namespace MoviesMafia.Services.Repositories;
 
 public sealed class MediaRequestRepository : Repository<MediaRequest>, IMediaRequestRepository
 {
-    public MediaRequestRepository(AppDbContext db) : base(db) { }
+    public MediaRequestRepository(IDbContextFactory<AppDbContext> dbFactory) : base(dbFactory) { }
 
     public async Task<IReadOnlyList<MediaRequest>> GetByUserAsync(string userId, CancellationToken ct = default) =>
         await Set.AsNoTracking()

--- a/Services/Repositories/Repository.cs
+++ b/Services/Repositories/Repository.cs
@@ -3,16 +3,25 @@ using MoviesMafia.Data;
 
 namespace MoviesMafia.Services.Repositories;
 
-/// <summary>EF Core implementation of <see cref="IRepository{T}"/>.</summary>
-public class Repository<T> : IRepository<T> where T : class
+/// <summary>
+/// EF Core implementation of <see cref="IRepository{T}"/>.
+///
+/// Owns a single <see cref="AppDbContext"/> created from <see cref="IDbContextFactory{TContext}"/>
+/// rather than sharing the request-scoped context. Under Blazor Static SSR / ReactiveBlazor,
+/// several components on one page (and out-of-band signal re-renders) run concurrently and would
+/// otherwise issue overlapping operations on a single shared context — which EF Core forbids
+/// ("A second operation was started on this context instance..."). Each repository instance is
+/// registered transient, so every consuming component gets its own isolated context.
+/// </summary>
+public class Repository<T> : IRepository<T>, IAsyncDisposable where T : class
 {
     protected readonly AppDbContext Db;
     protected readonly DbSet<T> Set;
 
-    public Repository(AppDbContext db)
+    public Repository(IDbContextFactory<AppDbContext> dbFactory)
     {
-        Db = db;
-        Set = db.Set<T>();
+        Db = dbFactory.CreateDbContext();
+        Set = Db.Set<T>();
     }
 
     public async Task<T?> GetByIdAsync(int id, CancellationToken ct = default) =>
@@ -29,4 +38,6 @@ public class Repository<T> : IRepository<T> where T : class
     public void Remove(T entity) => Set.Remove(entity);
 
     public Task<int> SaveChangesAsync(CancellationToken ct = default) => Db.SaveChangesAsync(ct);
+
+    public ValueTask DisposeAsync() => Db.DisposeAsync();
 }

--- a/Styles/app.tailwind.css
+++ b/Styles/app.tailwind.css
@@ -67,6 +67,10 @@
     a {
         @apply transition-colors;
     }
+
+    h1:focus {
+        outline: none;
+    }
 }
 
 @layer components {


### PR DESCRIPTION
Switch to AddDbContextFactory for AppDbContext to provide isolated, short-lived contexts per repository, preventing concurrency issues in Blazor SSR. Register repositories as transient and update them to use IDbContextFactory. Ensure Identity still receives a scoped context from the factory. Implement IAsyncDisposable in Repository<T> for proper context disposal. Add CSS to remove outline from focused h1 elements.